### PR TITLE
2022.2.16.1

### DIFF
--- a/dutch_gas_prices/CHANGELOG.md
+++ b/dutch_gas_prices/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2022.2.16.1
+
+**Important**: The sensor name for a single gas station is changed to its id instead of the street address
+
+- Single gas stations sensor name is changed to the id of the station
+- Unit of measurement is now always set
+- Sensor attributes for a single station is now the same as for a within radius request
+- Friendly name for single gas stations is now default "[brand] ([station_street])"
+- Error reporting updates
+- Documentation improvements
+
+
 ## 2022.1.2.1
 
 - Interaction with the tankservice website is more reliable

--- a/dutch_gas_prices/DOCS.md
+++ b/dutch_gas_prices/DOCS.md
@@ -47,9 +47,9 @@ While preprocessing the fuel station image, the contrast is enhanced. By default
 
 ## Home Assistant Sensor
 
-MQTT is used to automatically have sensors discovered. A sensor per gas station and per fuel_type will appear alongside the sensor.dutch_gas_prices_status. The latter one will provide information about the processing time.
+MQTT is used to automatically have sensors discovered. A sensor per gas station and per `fuel_type` will appear alongside the sensor.dutch_gas_prices_status. The latter one will provide information about the processing time.
 
-The following fuel_type can be used in the payloads below.
+The following `fuel_type` can be used in the payloads below.
 - euro95
 - euro98
 - diesel
@@ -57,7 +57,7 @@ The following fuel_type can be used in the payloads below.
 
 ### Gas stations based on location and radius
 
-Create an automation that will send a JSON payload to the correct MQTT topic
+Create an automation that will send a JSON payload to the correct MQTT topic. Replace `person.skons` with an entity that has latitude and longitude attributes.
 
 ```yaml
 automation:
@@ -72,7 +72,7 @@ automation:
       payload_template: '{"fuel_type":"euro95","radius":5,"latitude":{{ state_attr("person.skons", "latitude") }},"longitude":{{ state_attr("person.skons", "longitude") }}, "to_publish":3}'
 ```
 
-With to_publish you can determine how many of the discovered gas stations will show up, the default is 3. Gas stations with the lowest price will show up as:
+With `to_publish` you can determine how many of the cheapest discovered gas stations will show up, the default is 3. Gas stations with the lowest price will show up as:
 
 ```
 sensor.gas_station_[fuel_type]_lowest_price_1
@@ -89,11 +89,11 @@ This is what can be used as payload:
   "latitude": 6,
   "longitude": 53,
   "to_publish": 3 #Optional, default 3,
-  "friendly_name_template": "[brand] ([station_street])" #Optional, change the friendly name by using the attributes
+  "friendly_name_template": "[brand] ([station_street])" #Optional, change the friendly name by using the attributes of the sensor
 }
 ```
 
-To get a notification for the lowest gas station price after the latest price has been retreived, use the following automation:
+To get a notification for the lowest gas station price after the latest price has been retreived, use the following automation. Replace `[fuel_type]` with your fuel type:
 
 ```yaml
 - alias: Notify lowest price gas station
@@ -111,7 +111,7 @@ To get a notification for the lowest gas station price after the latest price ha
 
 ### Gas stations based on id
 
-Get the fuel_type information of a specific gas station. To get the ID of the gas station, go to https://directlease.nl/tankservice/ and click the gas station. Right click on the image and click open in new tab. ####.png is the id of your station.
+Get the `fuel_type` price information of a specific gas station. To get the ID of the gas station, go to https://directlease.nl/tankservice/ and click the gas station. Right click on the image and click open in new tab. `####.png` is the id of your station.
 
 ```yaml
 automation:
@@ -132,12 +132,12 @@ This is what can be used as payload:
 {
   "fuel_type": "euro95",
   "station_id": 1,
-  "friendly_name_template": "[brand] ([station_street])" #Optional, change the friendly name by using the attributes
+  "friendly_name_template": "[brand] ([station_street])" #Optional, change the friendly name by using the attributes of the sensor
 }
 ```
 
 ### Friendly name
-The friendly name can be configured by adding "friendly_name_template" to the MQTT payload. The value can contain every attribute you want which allows you to have a friendly name you desire. This could look something like this:
+The friendly name can be configured by adding `friendly_name_template` to the MQTT payload. The value can contain every attribute you want which allows you to have a friendly name you desire. This could look something like below. Please note that not all brands are known.:
 
 ```json
 "friendly_name_template": "[brand] ([station_street])"
@@ -153,7 +153,8 @@ Note: the attributes between the sensors from station based on radius and statio
 ## Troubleshooting
 
 - First check in the log of the addon if the addon is up and running
-- Check for log the addon is providing in the log file if things don't work out as expected
+- Enable debug logging to see if there is additional information that could help you fix the problem
+- Check for log the addon is providing in the log file if things don't work out as expected. If debug is enabled, please redact the username and password information in the log.
 
 ## Known Issues
 
@@ -161,4 +162,3 @@ Note: the attributes between the sensors from station based on radius and statio
 - Secure MQTT communication is not supported
 - If [Error -3] appears in the logging, and a DNS server is also running within Home Assistant, try to point HA to an external DNS server
 - aarch64 and i386 have not been tested
-- zone.home is initialized after the rest sensor, so the first query after a reboot will fail

--- a/dutch_gas_prices/config.json
+++ b/dutch_gas_prices/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Dutch gas prices",
-  "version": "2022.1.2.1",
+  "version": "2022.2.16.1",
   "slug": "dutch_gas_prices",
   "description": "Get gas prices from dutch gas stations",
   "url": "https://github.com/Skons/hassio-addons/tree/main/dutch_gas_prices",

--- a/dutch_gas_prices/rootfs/app/gas_stations.py
+++ b/dutch_gas_prices/rootfs/app/gas_stations.py
@@ -15,21 +15,20 @@ import pytesseract
 from fake_headers import Headers
 from geopy import distance
 from gas_station import gas_station
+from gas_station import get_all_stations
 from dgp_common import _read_cached_jsonfile
 from dgp_common import get_logger
-
-# Settings
-# Something like lru_cache would be nice but has no time expiring support, so custom json storage
-CACHE_TIME_STATIONS = 86400 #24h, could be longer, stations don't come and go very often
 
 logger = get_logger(__name__)
 
 def gas_stations(fuel,longitude,latitude,radius):
 	"""
-	Main Dutch Gas stations API Function
+	Get the prices of the gas stations within a radius for a specific location
+	:param fuel: The fuel type to get the gas price for
+	:param longitude: The longitude of the location to get the gas stations for
+	:param latitude: The latitude of the location to get the gas stations for
+	:param radius: The radius in kilomters to get the gas stations for
 	"""
-
-	url = f'https://tankservice.app-it-up.com/Tankservice/v1/places?fmt=web&fuel={fuel}'
 
 	def is_location_in_radius(lat, lon, station_lat, station_lon, km):
 		center_point = [{'lat': lat, 'lng': lon}]
@@ -46,57 +45,23 @@ def gas_stations(fuel,longitude,latitude,radius):
 		else:
 			return False
 
-	def _write_stationdata():
-		"""
-		Query the api and cache the results to a json file
-		"""
-		headers = Headers(headers=True).generate()
-
-		session = requests.Session()
-		retry = Retry(connect=3, backoff_factor=0.5)
-		adapter = HTTPAdapter(max_retries=retry)
-		session.mount('http://', adapter)
-		session.mount('https://', adapter)
-		response = session.get(url, headers=headers)
-		if response.status_code == 200:
-			data = response.json()
-
-			with open('cache/' + f'{fuel}.json', 'w') as outfile:
-					json.dump(data, outfile)
-		else:
-			logger.error(f"_write_stationdata: statuscode '{response.status_code}'")
-			logger.error(f"_write_stationdata: Used header '{headers}'")
-			ip_addr = requests.get('https://api.ipify.org').text
-			logger.error(f"_write_stationdata: Used IP '{ip_addr}'")
-			logger.error(f"_write_stationdata: Response text '{response.text}'")
-			data = {}
-		return data
-
 	# Main logic
-	stationdata = _read_cached_jsonfile('cache/' + f'{fuel}.json', CACHE_TIME_STATIONS)
-	if stationdata == False:
-		logger.debug(f"gas_stations: Fuel '{fuel}' new request")
-		stationdata = _write_stationdata()
+	stationdata = get_all_stations(fuel)
 
 	stations = []
 	for station in stationdata:
 		"""
 		Loop through all stations and find if they are within radius
 		"""
-		newstation = {}
-		newstation['brand'] = station['brand']
-		newstation['name'] = station['name']
 		station_lat = str(station['lat'])
-		newstation['latitude'] = float(station_lat[:2] + "." + station_lat[2:])#quick and dirty conversion of lat lon to float, should not be done this way
+		station_latitude = float(station_lat[:2] + "." + station_lat[2:])#quick and dirty conversion of lat lon to float, should not be done this way
 		station_lon = str(station['lng'])
-		newstation['longitude'] = float(station_lon[:1] + "." + station_lon[1:])
-		newstation['fuel'] = fuel
-		return_value = is_location_in_radius(latitude, longitude, newstation['latitude'] , newstation['longitude'], radius)
-		if return_value == True:
+		station_longitude = float(station_lon[:1] + "." + station_lon[1:])
+		return_value = is_location_in_radius(latitude, longitude, station_latitude, station_longitude, radius)
+		if return_value is True:
 			gasprices = gas_station(station['id'], fuel) #get the corresponding gas station and its prices
 			if 'price' in gasprices:
-				newstation = {**newstation, **gasprices}
-				stations.append(newstation)
+				stations.append(gasprices)
 
 	return_value = {}
 	return_value['gas_stations'] = sorted(stations, key=lambda x: x['price'], reverse=False) #sort on price, cheapest first


### PR DESCRIPTION
## 2022.2.16.1

**Important**: The sensor name for a single gas station is changed to its id instead of the street address

- Single gas stations sensor name is changed to the id of the station
- Unit of measurement is now always set
- Sensor attributes for a single station is now the same as for a within radius request
- Friendly name for single gas stations is now default "[brand] ([station_street])"
- Error reporting updates
- Documentation improvements

Fixed
#21 
#19 
#17 
