### PR TITLE
Set CallbackAPIVersion explicitly to VERSION1

### DIFF
--- a/dutch_gas_prices/rootfs/app/mqtt_client.py
+++ b/dutch_gas_prices/rootfs/app/mqtt_client.py
@@ -391,7 +391,7 @@ def start_mqtt_client(mqtt_host, mqtt_port, mqtt_username=None, mqtt_password=No
 
 	mqtt_client_name = os.environ.get("HOSTNAME")
 	logger.info(f"Connecting to mqtt host '{mqtt_host}' with clientname '{mqtt_client_name}'")
-	mqtt_client = mqtt.Client(mqtt_client_name)
+	mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, mqtt_client_name)
 	if mqtt_username:
 		logger.info(f"Using username '{mqtt_username}' to connect to '{mqtt_host}'")
 		mqtt_client.username_pw_set(username=mqtt_username, password=mqtt_password)

--- a/dutch_gas_prices_dev/rootfs/app/mqtt_client.py
+++ b/dutch_gas_prices_dev/rootfs/app/mqtt_client.py
@@ -391,7 +391,7 @@ def start_mqtt_client(mqtthost, mqttport, mqttusername=None, mqttpassword=None):
 	global mqtt_client
 
 	logger.info("Connecting mqtt")
-	mqtt_client = mqtt.Client("dutch_gas_prices")
+	mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, "dutch_gas_prices")
 	if mqttusername:
 		mqtt_client.username_pw_set(username=mqttusername, password=mqttpassword)
 	mqtt_client.on_connect = on_connect


### PR DESCRIPTION
.. attempt 2 :) 

Fixes https://github.com/Skons/hassio-addons/issues/65.

Based my fix on: https://stackoverflow.com/questions/77984857/paho-mqtt-unsupported-callback-api-version-error

I haven't deep-dived in whatever is required for this repo to build / deploy / anything. I implemented this in a fork, removed your addon in my HA, linked to my fork, installed and it worked (except that the API is complaining about a 403 as described in https://github.com/Skons/hassio-addons/issues/63, https://github.com/Skons/hassio-addons/issues/52, etc.).